### PR TITLE
Remove doc/ and sample/ from published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-label",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "text library for akashic",
   "main": "lib/index.js",
   "scripts": {
@@ -40,8 +40,6 @@
   },
   "files": [
     "lib",
-    "doc",
-    "sample",
     "package.json",
     "README.md",
     "akashic-label.md"


### PR DESCRIPTION
不要な doc/ と sample/ を publish 対象から除きます。(typedoc で自動生成される doc/ と node_modules/ を抱える sample/ は、不要でありながらファイルサイズの非常に大きい割合を占めていました。)
