### PR TITLE
make version 2.0.0; follow akashic-engine@2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.0.0
+
+* akashic-engine@2.0.0 系に追従。あわせてバージョンを 2.0.0 に。
+* 非推奨だった `LabelParameterObject#bitmapFont` および `RubyOptions#rubyBitmapFont` を削除。
+
 ## 0.3.5
 
 * publish対象から不要なファイルを除去。

--- a/akashic-label.md
+++ b/akashic-label.md
@@ -6,8 +6,8 @@ akashic-label は、Akashic Engine でルビ文字や複数行のテキスト描
 [sample/ ディレクトリ](./sample/) に本モジュールを使ったサンプルコンテンツが置いてあります。
 具体的な利用例についてはそちらを参照してください。
 
-**注意**: 現在の Akashic Engine(akashic-engine@1.10.1) には、このライブラリと同名の `Label` クラスが存在します ( `g.Label` ) 。
-akashic-label は、Akashic Engine の `g.Label`, `g.MultiLineLabel` の高機能版です。
+**注意**: 現在の Akashic Engine(akashic-engine@1.10.1 以降) には、このライブラリと同名の `Label` クラスが存在します ( `g.Label` ) 。
+akashic-label は、Akashic Engine の `g.Label`, `g.MultiLineLabel` (v2.0.0 で廃止) の高機能版です。
 このドキュメントで断りなく「ラベル」「 `Label` 」と書いてある場合、 akashic-label の `Label` を指します。
 
 ## 準備
@@ -41,7 +41,7 @@ akashic-label は Akashic Engine の `g.Label` と同じインターフェイス
 var label = new al.Label({
     scene: scene,
     text: "Hello!",
-    bitmapFont: bmpfont,
+    font: bmpfont,
     fontSize: 30,
     width: 180
 });
@@ -59,7 +59,7 @@ var text = '{"rt":"コーヒー","rb":"珈琲"}を飲む。';
 var label = new al.Label({
     scene: scene,
     text: text,
-    bitmapFont: bmpfont,
+    font: bmpfont,
     fontSize: 30,
     width: 200,
     lineBreak: false
@@ -78,7 +78,7 @@ var text = '{"rb": "車", "rt": "しゃ"}{"rb": "掌", "rt": "しょう"}';
 ### ルビ設定
 
 ルビのスタイルを指定するには、ラベルの `rubyOptions` プロパティを使用します。
-設定項目は `rubyFontSize` 、 `rubyBitmapFont` 、 `rubyGap` 、 `RubyAlign` があります。
+設定項目は `rubyFontSize` 、 `rubyFont` 、 `rubyGap` 、 `RubyAlign` があります。
 それぞれ「ルビのフォントサイズ」「ルビのフォント」「ルビと本文の間隔」「ルビのアライン」を表します。
 
 ```javascript
@@ -86,18 +86,18 @@ var text = '{"rt":"コーヒー","rb":"珈琲"}を飲む。';
 var label = new al.Label({
     scene: scene,
     text: text,
-    bitmapFont: bmpfont,
+    font: bmpfont,
     fontSize: 30,
     width: 200,
     lineBreak: false,
     rubyOptions: {
         rubyFontSize: 10,
-        rubyBitmapFont: rubyBitmapFont,
+        rubyFont: rubyFont,
         rubyGap: 2,
         rubyAlign: al.RubyAlign.Center
     }
 });
-// サンプルコードにおける `rubyBitmapFont` は、 `g.Bitmapfont` の値とします。
+// サンプルコードにおける `rubyFont` は、 `g.Bitmapfont` の値とします。
 ```
 
 各設定については akashic-label の [APIリファレンス](https://akashic-games.github.io/reference/akashic-label/index.html) 内の `RubyOptions` のページ、または [sample/ ディレクトリ](./sample/) 内のサンプルコードを参照してください。
@@ -136,7 +136,7 @@ akashic-label は自動改行と任意改行をサポートしています。
 var label = new al.Label({
     scene: scene,
     text: "1行目\r2行目",
-    bitmapFont: bmpfont,
+    font: bmpfont,
     fontSize: 30,
     width: 180,
     lineBreak: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-label",
-  "version": "0.3.5",
+  "version": "2.0.0",
   "description": "text library for akashic",
   "main": "lib/index.js",
   "scripts": {
@@ -10,7 +10,7 @@
     "build": "npm run clean && tsc",
     "doc": "typedoc --out ./doc",
     "lint": "npm run lint:ts && npm run lint:md",
-    "lint:ts": "tslint -c tslint.json src/**/*.ts",
+    "lint:ts": "tslint --type-check -c tslint.json --project ./tsconfig.json",
     "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ./.remarkrc",
     "test": "npm run build && npm run test:compile && npm run test:jasmine && npm run lint",
     "test:compile": "cd spec/ && tsc && cd ../",
@@ -27,13 +27,13 @@
     "remark-cli": "~2.0.0",
     "remark-lint": "~5.0.1",
     "rimraf": "^2.6.1",
-    "tslint": "^5.4.3",
+    "tslint": "~5.4.3",
     "typedoc": "^0.8.0",
     "typescript": "^2.1.6"
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/akashic-engine": "~1.10.1"
+    "@akashic/akashic-engine": "~2.0.0"
   },
   "files": [
     "lib",

--- a/sample/game/game.json
+++ b/sample/game/game.json
@@ -56,5 +56,8 @@
 		"node_modules/@akashic-extension/akashic-label/lib/FragmentDrawInfo.js",
 		"node_modules/@akashic-extension/akashic-label/lib/index.js",
 		"node_modules/@akashic-extension/akashic-label/package.json"
-	]
+	],
+	"environment": {
+		"sandbox-runtime": "2"
+	}
 }

--- a/sample/package.json
+++ b/sample/package.json
@@ -15,15 +15,15 @@
   "license": "",
   "devDependencies": {
     "@types/node": "6.0.46",
-    "@akashic/akashic-engine": "~1.10.1",
+    "@akashic/akashic-engine": "~2.0.0",
     "jasmine": "^2.1.1",
     "istanbul": "^0.3.2",
     "typescript": "^2.1.6",
     "tslint": "^5.4.3"
   },
   "dependencies": {
-    "@akashic-extension/akashic-label": "0.3.3",
+    "@akashic-extension/akashic-label": "2.0.0",
     "@akashic/akashic-cli": "^1.0.8",
-    "@akashic/akashic-sandbox": "^0.10.1"
+    "@akashic/akashic-sandbox": "^0.13.7"
   }
 }

--- a/sample/script/mainScene.ts
+++ b/sample/script/mainScene.ts
@@ -7,7 +7,7 @@ export = function() {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 3;
-	scene.loaded.handle(function() {
+	scene.loaded.add(function() {
 
 		var labels: Label[] = [];
 
@@ -15,13 +15,13 @@ export = function() {
 		var glyph = JSON.parse((<g.TextAsset>scene.assets["mplus-glyph"]).data);
 
 		// ビットマップフォント画像とグリフ情報からBitmapFontのインスタンスを生成
-		var mplusfont = new g.BitmapFont(
-			scene.assets["mplus"],
-			glyph.map,
-			glyph.width,
-			glyph.height,
-			glyph.missingGlyph
-		);
+		var mplusfont = new g.BitmapFont({
+			src: scene.assets["mplus"],
+			map: glyph.map,
+			defaultGlyphWidth: glyph.width,
+			defaultGlyphHeight: glyph.height,
+			missingGlyph: glyph.missingGlyph
+		});
 
 		var dhint: g.DynamicFontHint = {
 			initialAtlasWidth: 256,
@@ -30,7 +30,12 @@ export = function() {
 			maxAtlasHeight: 256,
 			maxAtlasNum: 8
 		}
-		var dfont = new g.DynamicFont(g.FontFamily.Monospace, 40, scene.game, dhint);
+		var dfont = new g.DynamicFont({
+			game: scene.game,
+			fontFamily: g.FontFamily.Monospace,
+			size: 40,
+			hint: dhint
+		});
 
 		// ラベル基本機能
 		var tlabel0 = new Label({
@@ -71,13 +76,13 @@ export = function() {
 		label02.x = game.width / 4;
 		label02.y = y0;
 		label02.touchable = true;
-		label02.update.handle(label02, function(){
+		label02.update.add(function(){
 			if (game.age % rate === 0) {
 				this.textColor = colors[counter02 % colors.length];
 				counter02++;
 				this.invalidate();
 			}
-		})
+		}, label02);
 		scene.append(label02);
 
 		// フォントサイズの変更
@@ -92,13 +97,13 @@ export = function() {
 		label03.x = game.width / 4 * 2;
 		label03.y = y0;
 		label03.touchable = true;
-		label03.update.handle(label03, function(){
+		label03.update.add(function(){
 			if (game.age % rate === 0) {
 				this.fontSize = (counter03 % 6) * 3 + 5;
 				counter03++;
 				this.invalidate();
 			}
-		})
+		}, label03);
 		scene.append(label03);
 
 		// テキスト位置の調整
@@ -155,13 +160,13 @@ export = function() {
 		});
 		label21.y = y2;
 		scene.append(label21);
-		label21.update.handle(label21, function(){
+		label21.update.add(function(){
 			if (game.age % rate === 0) {
 				this.textAlign = aligns21[counter21 % 3];
 				counter21++;
 				this.invalidate();
 			}
-		});
+		}, label21);
 
 		// lineGapを使った行間調整
 		var counter22 = 0;
@@ -175,13 +180,13 @@ export = function() {
 		});
 		label22.y = y2 + 50;
 		label22.touchable = true;
-		label22.update.handle(label22, function(){
+		label22.update.add(function(){
 			if (game.age % rate === 0) {
 				this.lineGap = Math.round(counter22 % 10) - 5;
 				counter22++;
 				this.invalidate();
 			}
-		})
+		}, label22);
 		scene.append(label22);
 
 		// width基準による自動改行
@@ -196,13 +201,13 @@ export = function() {
 		label23.x = 150;
 		label23.y = y2 + 50;;
 		scene.append(label23);
-		label23.update.handle(label23, function(){
+		label23.update.add(function(){
 			if (game.age % rate === 0) {
 				this.width = counter23 % 10 * 10 + 100;
 				counter23;
 				this.invalidate();
 			}
-		})
+		}, label23);
 
 		// 自動改行オフ
 		var label24 = new Label({
@@ -213,14 +218,14 @@ export = function() {
 			width: game.width,
 			lineBreak: false
 		});
-		label24.y = y2+150;
+		label24.y = y2 + 150;
 		label24.touchable = true;
-		label24.update.handle(label24, function(){
+		label24.update.add(function(){
 			if (game.age % rate === 0) {
 				this.lineBreak = !this.lineBreak;
 				this.invalidate();
 			}
-		})
+		}, label24);
 		scene.append(label24);
 
 		var nlabel = new Label({
@@ -233,10 +238,10 @@ export = function() {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.handle(nlabel, function(){
+		nlabel.pointDown.add(function(){
 			var scene2 = require("mainScene2")();
 			game.replaceScene(scene2);
-		});
+		}, nlabel);
 		scene.append(nlabel);
 
 		var dlabel = new Label({
@@ -250,15 +255,19 @@ export = function() {
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.handle(dlabel, function(){
+		dlabel.pointDown.add(function(){
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;
-					label.rubyOptions.rubyFont = new g.DynamicFont(g.FontFamily.Monospace, 40, scene.game);
+					label.rubyOptions.rubyFont = new g.DynamicFont({
+						game: scene.game,
+						fontFamily: g.FontFamily.Monospace,
+						size: 40
+					});
 					label.invalidate();
 				}
 			});
-		});
+		}, dlabel);
 
 		scene.append(dlabel);
 	});

--- a/sample/script/mainScene2.ts
+++ b/sample/script/mainScene2.ts
@@ -7,27 +7,27 @@ module.exports = function() {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 6;
-	scene.loaded.handle(function() {
+	scene.loaded.add(function() {
 
 		// グリフデータの生成
 		var mplusGlyph = JSON.parse((<g.TextAsset>scene.assets["mplus-glyph"]).data);
 
 		// ビットマップフォント画像とグリフ情報からBitmapFontのインスタンスを生成
-		var mplusfont = new g.BitmapFont(
-			scene.assets["mplus"],
-			mplusGlyph.map,
-			mplusGlyph.width,
-			mplusGlyph.height,
-			mplusGlyph.missingGlyph
-		);
+		var mplusfont = new g.BitmapFont({
+			src: scene.assets["mplus"],
+			map: mplusGlyph.map,
+			defaultGlyphWidth: mplusGlyph.width,
+			defaultGlyphHeight: mplusGlyph.height,
+			missingGlyph: mplusGlyph.missingGlyph
+		});
 		var glyph = JSON.parse((<g.TextAsset>scene.assets["bmpfont-glyph"]).data);
-		var bmpfont = new g.BitmapFont(
-			scene.assets["bmpfont"],
-			glyph.map,
-			glyph.width,
-			glyph.height,
-			glyph.missingGlyph
-		);
+		var bmpfont = new g.BitmapFont({
+			src: scene.assets["bmpfont"],
+			map: glyph.map,
+			defaultGlyphWidth: glyph.width,
+			defaultGlyphHeight: glyph.height,
+			missingGlyph: glyph.missingGlyph
+		});
 
 		var dhint: g.DynamicFontHint = {
 			initialAtlasWidth: 256,
@@ -36,7 +36,12 @@ module.exports = function() {
 			maxAtlasHeight: 256,
 			maxAtlasNum: 8
 		}
-		var dfont = new g.DynamicFont(g.FontFamily.Monospace, 40, scene.game, dhint);
+		var dfont = new g.DynamicFont({
+			game: scene.game,
+			fontFamily: g.FontFamily.Monospace,
+			size: 40,
+			hint: dhint
+		});
 
 		// ラベルのルビ基本機能
 		var tlabel0 = new Label({
@@ -88,13 +93,13 @@ module.exports = function() {
 		label03.x = 0;
 		label03.y = y0 + 90;
 		label03.touchable = true;
-		label03.update.handle(label03, function() {
+		label03.update.add(function() {
 			if (game.age % rate === 0) {
 				this.rubyOptions.rubyGap = counter03 % 4 - 5;
 				counter03++;
 				this.invalidate();
 			}
-		});
+		}, label03);
 		scene.append(label03);
 
 		// ルビのフォントサイズ
@@ -111,13 +116,13 @@ module.exports = function() {
 		label04.y = y0 + 90;
 		label04.touchable = true;
 		scene.append(label04);
-		label04.update.handle(label04,function() {
+		label04.update.add(function() {
 			if (game.age % rate === 0) {
 				this.rubyOptions.rubyFontSize = counter04 % 5 + 15;
 				counter04++;
 				this.invalidate();
 			}
-		});
+		}, label04);
 
 		// ルビフォントの指定
 		var label05 = new Label({
@@ -132,7 +137,7 @@ module.exports = function() {
 		label05.y = y0 + 90;
 		label05.touchable = true;
 		scene.append(label05);
-		label05.update.handle(label05,function() {
+		label05.update.add(function() {
 			if (game.age % rate === 0) {
 				if (this.rubyOptions.rubyFont === bmpfont) {
 					this.rubyOptions.rubyFont = mplusfont;
@@ -141,7 +146,7 @@ module.exports = function() {
 				}
 				this.invalidate();
 			}
-		});
+		}, label05);
 
 		// ルビ位置の調整 SpaceAround
 		var y1 = 170;
@@ -178,10 +183,10 @@ module.exports = function() {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.handle(nlabel, function() {
+		nlabel.pointDown.add(function() {
 			var scene3 = require("mainScene3")();
 			game.replaceScene(scene3);
-		});
+		}, nlabel);
 		scene.append(nlabel);
 		var dlabel = new Label({
 			scene: scene,
@@ -194,7 +199,7 @@ module.exports = function() {
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.handle(dlabel, function(){
+		dlabel.pointDown.add(function(){
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;
@@ -202,7 +207,7 @@ module.exports = function() {
 					label.invalidate();
 				}
 			});
-		});
+		}, dlabel);
 		scene.append(dlabel);
 
 	});

--- a/sample/script/mainScene3.ts
+++ b/sample/script/mainScene3.ts
@@ -6,31 +6,31 @@ module.exports = function() {
 		game: game,
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
-	scene.loaded.handle(function() {
+	scene.loaded.add(function() {
 
 		// グリフデータの生成
 		var mplusGlyph = JSON.parse((<g.TextAsset>scene.assets["mplus-glyph"]).data);
 
 		// ビットマップフォント画像とグリフ情報からBitmapFontのインスタンスを生成
-		var mplusfont = new g.BitmapFont(
-			scene.assets["mplus"],
-			mplusGlyph.map,
-			mplusGlyph.width,
-			mplusGlyph.height,
-			mplusGlyph.missingGlyph
-		);
+		var mplusfont = new g.BitmapFont({
+			src: scene.assets["mplus"],
+			map: mplusGlyph.map,
+			defaultGlyphWidth: mplusGlyph.width,
+			defaultGlyphHeight: mplusGlyph.height,
+			missingGlyph: mplusGlyph.missingGlyph
+		});
 
 		// グリフデータの生成
 		var glyph = JSON.parse((<g.TextAsset>scene.assets["bmpfont-glyph"]).data);
 
 		// ビットマップフォント画像とグリフ情報からBitmapFontのインスタンスを生成
-		var bmpfont = new g.BitmapFont(
-			scene.assets["bmpfont"],
-			glyph.map,
-			glyph.width,
-			glyph.height,
-			glyph.missingGlyph
-		);
+		var bmpfont = new g.BitmapFont({
+			src: scene.assets["bmpfont"],
+			map: glyph.map,
+			defaultGlyphWidth: glyph.width,
+			defaultGlyphHeight: glyph.height,
+			missingGlyph: glyph.missingGlyph
+		});
 
 		var dhint: g.DynamicFontHint = {
 			initialAtlasWidth: 256,
@@ -39,7 +39,12 @@ module.exports = function() {
 			maxAtlasHeight: 256,
 			maxAtlasNum: 8
 		}
-		var dfont = new g.DynamicFont(g.FontFamily.Monospace, 40, scene.game, dhint);
+		var dfont = new g.DynamicFont({
+			game: scene.game,
+			fontFamily: g.FontFamily.Monospace,
+			size: 40,
+			hint: dhint
+		});
 
 		// ルビ機能2
 		var tlabel0 = new Label({
@@ -121,10 +126,10 @@ module.exports = function() {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.handle(nlabel, function() {
+		nlabel.pointDown.add(function() {
 			var scene3 = require("mainScene4")();
 			game.replaceScene(scene3);
-		});
+		}, nlabel);
 		scene.append(nlabel);
 		var dlabel = new Label({
 			scene: scene,
@@ -137,7 +142,7 @@ module.exports = function() {
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.handle(dlabel, function(){
+		dlabel.pointDown.add(function(){
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;
@@ -145,7 +150,7 @@ module.exports = function() {
 					label.invalidate();
 				}
 			});
-		});
+		}, dlabel);
 		scene.append(dlabel);
 
 	});

--- a/sample/script/mainScene4.ts
+++ b/sample/script/mainScene4.ts
@@ -7,31 +7,31 @@ module.exports = function() {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 3;
-	scene.loaded.handle(function() {
+	scene.loaded.add(function() {
 
 		// グリフデータの生成
 		var mplusGlyph = JSON.parse((<g.TextAsset>scene.assets["mplus-glyph"]).data);
 
 		// ビットマップフォント画像とグリフ情報からBitmapFontのインスタンスを生成
-		var mplusfont = new g.BitmapFont(
-			scene.assets["mplus"],
-			mplusGlyph.map,
-			mplusGlyph.width,
-			mplusGlyph.height,
-			mplusGlyph.missingGlyph
-		);
+		var mplusfont = new g.BitmapFont({
+			src: scene.assets["mplus"],
+			map: mplusGlyph.map,
+			defaultGlyphWidth: mplusGlyph.width,
+			defaultGlyphHeight: mplusGlyph.height,
+			missingGlyph: mplusGlyph.missingGlyph
+		});
 
 		// グリフデータの生成
 		var glyph = JSON.parse((<g.TextAsset>scene.assets["bmpfont-glyph"]).data);
 
 		// ビットマップフォント画像とグリフ情報からBitmapFontのインスタンスを生成
-		var bmpfont = new g.BitmapFont(
-			scene.assets["bmpfont"],
-			glyph.map,
-			glyph.width,
-			glyph.height,
-			glyph.missingGlyph
-		);
+		var bmpfont = new g.BitmapFont({
+			src: scene.assets["bmpfont"],
+			map: glyph.map,
+			defaultGlyphWidth: glyph.width,
+			defaultGlyphHeight: glyph.height,
+			missingGlyph: glyph.missingGlyph
+		});
 
 		var dhint: g.DynamicFontHint = {
 			initialAtlasWidth: 256,
@@ -40,7 +40,12 @@ module.exports = function() {
 			maxAtlasHeight: 256,
 			maxAtlasNum: 8
 		}
-		var dfont = new g.DynamicFont(g.FontFamily.Monospace, 40, scene.game, dhint);
+		var dfont = new g.DynamicFont({
+			game: scene.game,
+			fontFamily: g.FontFamily.Monospace,
+			size: 40,
+			hint: dhint
+		});
 
 		// パーサ切替とエスケープ文字
 		var tlabel0 = new Label({
@@ -102,13 +107,13 @@ module.exports = function() {
 		label00.x = 0;
 		label00.y = y0;
 		scene.append(label00);
-		label00.update.handle(label00, function() {
+		label00.update.add(function() {
 			if (game.age % rate === 0) {
 				this.width = counter00 % 20 * 10 + 120;
 				counter00++;
 				this.invalidate();
 			}
-		});
+		}, label00);
 
 		// エスケープ文字の利用方法
 		var label01 = new Label({
@@ -132,10 +137,10 @@ module.exports = function() {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.handle(nlabel, function() {
+		nlabel.pointDown.add(function() {
 			var scene3 = require("mainScene5")();
 			game.replaceScene(scene3);
-		});
+		}, nlabel);
 		scene.append(nlabel);
 
 		var dlabel = new Label({
@@ -149,7 +154,7 @@ module.exports = function() {
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.handle(dlabel, function(){
+		dlabel.pointDown.add(function(){
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;
@@ -157,7 +162,7 @@ module.exports = function() {
 					label.invalidate();
 				}
 			});
-		});
+		}, dlabel);
 		scene.append(dlabel);
 
 	});

--- a/sample/script/mainScene5.ts
+++ b/sample/script/mainScene5.ts
@@ -7,31 +7,31 @@ module.exports = function() {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 2;
-	scene.loaded.handle(function() {
+	scene.loaded.add(function() {
 
 		// グリフデータの生成
 		var mplusGlyph = JSON.parse((<g.TextAsset>scene.assets["mplus-glyph"]).data);
 
 		// ビットマップフォント画像とグリフ情報からBitmapFontのインスタンスを生成
-		var mplusfont = new g.BitmapFont(
-			scene.assets["mplus"],
-			mplusGlyph.map,
-			mplusGlyph.width,
-			mplusGlyph.height,
-			mplusGlyph.missingGlyph
-		);
+		var mplusfont = new g.BitmapFont({
+			src: scene.assets["mplus"],
+			map: mplusGlyph.map,
+			defaultGlyphWidth: mplusGlyph.width,
+			defaultGlyphHeight: mplusGlyph.height,
+			missingGlyph: mplusGlyph.missingGlyph
+		});
 
 		// グリフデータの生成
 		var glyph = JSON.parse((<g.TextAsset>scene.assets["bmpfont-glyph"]).data);
 
 		// ビットマップフォント画像とグリフ情報からBitmapFontのインスタンスを生成
-		var bmpfont = new g.BitmapFont(
-			scene.assets["bmpfont"],
-			glyph.map,
-			glyph.width,
-			glyph.height,
-			glyph.missingGlyph
-		);
+		var bmpfont = new g.BitmapFont({
+			src: scene.assets["bmpfont"],
+			map: glyph.map,
+			defaultGlyphWidth: glyph.width,
+			defaultGlyphHeight: glyph.height,
+			missingGlyph: glyph.missingGlyph
+		});
 
 		var dhint: g.DynamicFontHint = {
 			initialAtlasWidth: 256,
@@ -40,7 +40,12 @@ module.exports = function() {
 			maxAtlasHeight: 256,
 			maxAtlasNum: 8
 		}
-		var dfont = new g.DynamicFont(g.FontFamily.Monospace, 40, scene.game, dhint);
+		var dfont = new g.DynamicFont({
+			game: scene.game,
+			fontFamily: g.FontFamily.Monospace,
+			size: 40,
+			hint: dhint
+		});
 
 		// 複数行のルビ機能
 		var tlabel0 = new Label({
@@ -66,16 +71,16 @@ module.exports = function() {
 			fontSize: 20,
 			width: game.width,
 			fixLineGap: false,
-			rubyOptions: {rubyBitmapFont: bmpfont}
+			rubyOptions: {rubyFont: bmpfont}
 		});
 		label01.y = y0;
 		label01.touchable = true;
-		label01.update.handle(label01, function() {
+		label01.update.add(function() {
 			if (game.age % rate === 0) {
 				label01.fixLineGap = !label01.fixLineGap;
 				label01.invalidate();
 			}
-		});
+		}, label01);
 		scene.append(label01);
 
 		// ルビ応用
@@ -129,7 +134,7 @@ module.exports = function() {
 		counter = 0;
 		mlabel.textAlign = g.TextAlign.Left;
 		scene.append(mlabel);
-		mlabel.update.handle(mlabel, function() {
+		mlabel.update.add(function() {
 			// 初期化と待機
 			if (counter === textArray.length) {
 				this.text = "";
@@ -144,14 +149,14 @@ module.exports = function() {
 						counter += 1;
 						this.text += textArray[counter];
 
-					}else{
+					} else {
 						this.text += textArray[counter];
 					}
 					this.invalidate();
 				}
 				counter += 1;
 			}
-		});
+		}, mlabel);
 
 		var dlabel = new Label({
 			scene: scene,
@@ -164,7 +169,7 @@ module.exports = function() {
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.handle(dlabel, function(){
+		dlabel.pointDown.add(function(){
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;
@@ -172,7 +177,7 @@ module.exports = function() {
 					label.invalidate();
 				}
 			});
-		});
+		}, dlabel);
 		scene.append(dlabel);
 
 	});

--- a/spec/LabelSpec.js
+++ b/spec/LabelSpec.js
@@ -19,14 +19,20 @@ describe("test Label", function() {
 		var height = 350;
 		var map = {"37564": {"x": 0, "y": 1}};
 		var missingGlyph = {"x": 2, "y": 3};
-		bmpfont = new g.BitmapFont(new mock.ResourceFactory().createImageAsset("testId", "testAssetPath", width, height), map, 50, 50, missingGlyph);
+		bmpfont = new g.BitmapFont({
+			src: new mock.ResourceFactory().createImageAsset("testId", "testAssetPath", width, height),
+			map: map,
+			defaultGlyphWidth: 50,
+			defaultGlyphHeight: 50,
+			missingGlyph: missingGlyph
+		});
 	});
 
 	afterEach(function() {
 	});
 
 	it("初期化", function() {
-        var mlabel = new Label({
+		var mlabel = new Label({
 			scene: runtime.scene,
 			text: "foo",
 			font: bmpfont,
@@ -209,9 +215,9 @@ describe("test Label", function() {
 			rubyFont: bmpfont,
 			rubyGap: 20,
 			rubyAlign: rt.RubyAlign.Center
-		}
+		};
 		mlabel.invalidate();
-			var mlabel2 = new Label({
+		var mlabel2 = new Label({
 			scene: runtime.scene,
 			text: "b",
 			textColor: "red",
@@ -236,9 +242,7 @@ describe("test Label", function() {
 		expect(mlabel.height).toEqual(mlabel2.height);
 		expect(mlabel.lineBreak).toEqual(mlabel2.lineBreak);
 		expect(mlabel.lineGap).toEqual(mlabel2.lineGap);
-		expect(mlabel.rubyOptions).not.toEqual(mlabel2.rubyOptions);
-		expect(mlabel.rubyOptions.rubyFont).toEqual(mlabel2.rubyOptions.rubyFont);
-
+		expect(mlabel.rubyOptions).toEqual(mlabel2.rubyOptions);
 	});
 
 	it("_divideToLines", function(){

--- a/spec/helpers/mock.ts
+++ b/spec/helpers/mock.ts
@@ -155,6 +155,20 @@ export class Renderer extends g.Renderer {
 			}
 		});
 	}
+
+	setTransform(matrix: number[]): void {
+		this.methodCallHistoryWithParams.push({
+			methodName: "setTransform",
+			params: { matrix }
+		});
+	}
+
+	setOpacity(opacity: number): void {
+		this.methodCallHistoryWithParams.push({
+			methodName: "setOpacity",
+			params: { opacity }
+		});
+	}
 }
 
 class Surface extends g.Surface {
@@ -167,6 +181,10 @@ class Surface extends g.Surface {
 		var r = new Renderer();
 		this.createdRenderer = r;
 		return r;
+	}
+
+	isPlaying(): boolean {
+		return false;
 	}
 }
 
@@ -282,8 +300,9 @@ export class DelayedImageAsset extends ImageAsset implements DelayedAsset {
 class AudioAsset extends g.AudioAsset {
 	_failureController: LoadFailureController;
 
-	constructor(necessaryRetryCount: number, id: string, assetPath: string, duration: number, system: g.AudioSystem) {
-		super(id, assetPath, duration, system);
+	constructor(necessaryRetryCount: number, id: string, assetPath: string, duration: number,
+	            system: g.AudioSystem, loop: boolean, hint: g.AudioAssetHint) {
+		super(id, assetPath, duration, system, loop, hint);
 		this._failureController = new LoadFailureController(necessaryRetryCount);
 	}
 
@@ -346,7 +365,7 @@ class ScriptAsset extends g.ScriptAsset {
 			// 特にスクリプトの内容指定がないケース:
 			// ScriptAssetは任意の値を返してよいが、シーンを記述したスクリプトは
 			// シーンを返す関数を返すことを期待するのでここでは関数を返しておく
-			return env.module.exports = function () { return new g.Scene(env.game); };
+			return env.module.exports = function () { return new g.Scene({ game: env.game }); };
 
 		} else {
 			var prefix = "(function(exports, require, module, __filename, __dirname) {";
@@ -415,8 +434,17 @@ export class ResourceFactory extends g.ResourceFactory {
 		}
 	}
 
-	createAudioAsset(id: string, assetPath: string, duration: number, system: g.AudioSystem): g.AudioAsset {
-		return new AudioAsset(this._necessaryRetryCount, id, assetPath, duration, system);
+	createVideoAsset(id: string, assetPath: string, width: number, height: number,
+	                 system: g.VideoSystem, loop: boolean, useRealSize: boolean): g.VideoAsset {
+		throw new Error("not implemented");
+	}
+
+	createAudioAsset(id: string, assetPath: string, duration: number, system: g.AudioSystem, loop: boolean, hint: g.AudioAssetHint): g.AudioAsset {
+		return new AudioAsset(this._necessaryRetryCount, id, assetPath, duration, system, loop, hint);
+	}
+
+	createAudioPlayer(system: g.AudioSystem): g.AudioPlayer {
+		throw new Error("not implemented");
 	}
 
 	createTextAsset(id: string, assetPath: string): g.TextAsset {
@@ -429,6 +457,12 @@ export class ResourceFactory extends g.ResourceFactory {
 
 	createSurface(width: number, height: number): g.Surface {
 		return new Surface(width, height);
+	}
+
+	createGlyphFactory(fontFamily: g.FontFamily | string | (g.FontFamily | string)[],
+	                   fontSize: number, baselineHeight?: number, fontColor?: string,
+	                   strokeWidth?: number, strokeColor?: string, strokeOnly?: boolean, fontWeight?: g.FontWeight): g.GlyphFactory {
+		throw new Error("not implemented");
 	}
 }
 
@@ -464,6 +498,18 @@ export class Game extends g.Game {
 
 	saveSnapshot(snapshot: any): void {
 		// do nothing.
+	}
+
+	addEventFilter(filter: g.EventFilter): void {
+		throw new Error("not implemented");
+	}
+
+	removeEventFilter(filter: g.EventFilter): void {
+		throw new Error("not implemented");
+	}
+
+	raiseTick(events?: g.Event[]): void {
+		throw new Error("not implemented");
 	}
 }
 

--- a/spec/helpers/skeleton.ts
+++ b/spec/helpers/skeleton.ts
@@ -4,7 +4,7 @@ function skeletonRuntime(gameConfiguration?: g.GameConfiguration) {
 	if (!gameConfiguration)
 		gameConfiguration = { width: 320, height: 320 };
 	var game = new mock.Game(gameConfiguration);
-	var scene = new g.Scene(game);
+	var scene = new g.Scene({ game });
 	game.pushScene(scene);
 	game._flushSceneChangeRequests();
 	return {

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -24,7 +24,7 @@ interface LineDividingState {
  * 複数行のテキストを描画するエンティティ。
  * 文字列内の"\r\n"、"\n"、"\r"を区切りとして改行を行う。
  * また、自動改行が有効な場合はエンティティの幅に合わせて改行を行う。
- * 本クラスの利用にはg.BitmapFontが必要となる。
+ * 本クラスの利用にはg.Fontが必要となる。
  */
 class Label extends g.CacheableE {
 	/**
@@ -32,13 +32,6 @@ class Label extends g.CacheableE {
 	 * この値を変更した場合、 `this.invalidate()` を呼び出す必要がある。
 	 */
 	text: string;
-
-	/**
-	 * 描画に利用されるフォント。
-	 * この値を変更した場合、 `this.invalidate()` を呼び出す必要がある。
-	 * @deprecated このプロパティは非推奨であり、後方互換性のために存在する。代わりに`font`プロパティを用いるべきである。
-	 */
-	bitmapFont: g.BitmapFont;
 
 	/**
 	 * 描画に利用されるフォント。
@@ -127,7 +120,7 @@ class Label extends g.CacheableE {
 	 * 個別のルビに `this.rubyOptions` の各プロパティと同名のプロパティが存在する場合、個別のルビの設定が優先される。
 	 *
 	 * rubyFontSize: ルビのフォントサイズ。初期値は `this.fontSize / 2` である。
-	 * rubyBitmapFont: ルビのビットマップフォント。初期値は `this.bitmapFont` である。
+	 * rubyFont: ルビのビットマップフォント。初期値は `this.font` である。
 	 * rubyGap: ルビと本文の行間。初期値は0である。
 	 * rubyAlign: ルビのレイアウト。初期値は `RubyAlign.SpaceAround` である。
 	 *
@@ -162,13 +155,9 @@ class Label extends g.CacheableE {
 	 * @param param このエンティティに対するパラメータ
 	 */
 	constructor(param: LabelParameterObject) {
-		if (!param.font && !param.bitmapFont) {
-			throw g.ExceptionFactory.createAssertionError("Label#constructor: 'font' or 'bitmapFont' must be given to LabelParameterObject");
-		}
 		super(param);
 		this.text = param.text;
-		this.bitmapFont = param.bitmapFont;
-		this.font = param.font ? param.font : param.bitmapFont;
+		this.font = param.font;
 		this.fontSize = param.fontSize;
 		this._lineBreakWidth = param.width;
 		this.lineBreak = "lineBreak" in param ? param.lineBreak : true;
@@ -186,7 +175,6 @@ class Label extends g.CacheableE {
 		}
 		this.rubyOptions = param.rubyOptions;
 		this.rubyOptions.rubyFontSize = "rubyFontSize" in param.rubyOptions ? param.rubyOptions.rubyFontSize : param.fontSize / 2;
-		this.rubyOptions.rubyBitmapFont = "rubyBitmapFont" in param.rubyOptions ? param.rubyOptions.rubyBitmapFont : this.bitmapFont;
 		this.rubyOptions.rubyFont = "rubyFont" in param.rubyOptions ? param.rubyOptions.rubyFont : this.font;
 		this.rubyOptions.rubyGap = "rubyGap" in param.rubyOptions ? param.rubyOptions.rubyGap : 0;
 		this.rubyOptions.rubyAlign = "rubyAlign" in param.rubyOptions ? param.rubyOptions.rubyAlign : rp.RubyAlign.SpaceAround;
@@ -243,7 +231,7 @@ class Label extends g.CacheableE {
 
 	/**
 	 * 利用している `g.Surface` を破棄した上で、このエンティティを破棄する。
-	 * 利用している `g.BitmapFont` の破棄は行わないため、 `g.BitmapFont` の破棄はコンテンツ製作者が明示的に行う必要がある。
+	 * 利用している `g.Font` の破棄は行わないため、 `g.Font` の破棄はコンテンツ製作者が明示的に行う必要がある。
 	 */
 	destroy(): void {
 		this._destroyLines();
@@ -278,15 +266,6 @@ class Label extends g.CacheableE {
 
 		if (this.lineGap < -1 * this.fontSize)
 			throw g.ExceptionFactory.createAssertionError("Label#_invalidateSelf: lineGap must be greater than -1 * fontSize.");
-
-		// bitmapFontが定義されている場合、bitmapfontを利用する。
-		if (this.bitmapFont !== undefined) {
-			this.font = this.bitmapFont;
-		}
-
-		if (this.rubyOptions.rubyBitmapFont !== undefined) {
-			this.rubyOptions.rubyFont = this.rubyOptions.rubyBitmapFont;
-		}
 
 		// this.width がユーザから変更された場合、this._lineBreakWidth は this.width に追従する。
 		if (this._beforeWidth !== this.width) this._lineBreakWidth = this.width;

--- a/src/LabelParameterObject.ts
+++ b/src/LabelParameterObject.ts
@@ -1,7 +1,6 @@
 import rt = require("./RubyParser");
 /**
  * `Label` のコンストラクタに渡すことができるパラメータ。
- * 各メンバの詳細は `Label` の同名メンバの説明を参照すること。
  */
 interface LabelParameterObject extends g.CacheableEParameterObject {
 	/**
@@ -11,23 +10,15 @@ interface LabelParameterObject extends g.CacheableEParameterObject {
 
 	/**
 	 * 描画に利用されるフォント。
-	 * @deprecated このプロパティは非推奨であり、後方互換性のために存在する。代わりに`font`プロパティを用いるべきである。
 	 */
-	bitmapFont?: g.BitmapFont;
-
-	/**
-	 * 描画に利用されるフォント。
-	 * この値または`bitmapFont`が指定されなければならない。
-	 */
-	font?: g.Font;
+	font: g.Font;
 
 	/**
 	 * フォントサイズ。
 	 * 0 以上の数値でなければならない。
-	 * これは `LabelParameterObject#font` または `LabelParameterObject#bitmapFont` で
-	 * 与えられたフォントを `fontSize` フォントサイズ相当で描画するよう指示する値である。
-	 * 歴史的経緯によりフォントサイズと説明されているが、実際には拡大縮小率を求めるため
-	 * に用いられている。
+	 * これは `LabelParameterObject#font` に与えられたフォントを
+	 * `fontSize` フォントサイズ相当で描画するよう指示する値である。
+	 * 歴史的経緯によりフォントサイズと説明されているが、実際には拡大縮小率を求めるために用いられている。
 	 */
 	fontSize: number;
 

--- a/src/RubyParser.ts
+++ b/src/RubyParser.ts
@@ -5,12 +5,6 @@ export interface RubyOptions {
 	rubyFontSize?: number;
 
 	/**
-	 * ルビのビットマップフォント。
-	 * @deprecated このプロパティは非推奨であり、後方互換性のために存在する。代わりに`rubyFont`プロパティを用いるべきである。
-	 */
-	rubyBitmapFont?: g.BitmapFont;
-
-	/**
 	 * ルビのフォント。
 	 */
 	rubyFont?: g.Font;

--- a/tslint.json
+++ b/tslint.json
@@ -18,11 +18,15 @@
     "label-position": true,
     "max-line-length": [true, 140],
     "member-ordering": [true, {
-        "order": [
-          "public-before-private",
-          "static-before-instance",
-          "variables-before-functions"
-      ]}
+       "order": [
+         "public-static-field",
+         "public-static-method",
+         "public-instance-field",
+         "private-instance-field",
+         "public-constructor",
+         "public-instance-method",
+         "private-instance-method"
+       ]}
     ],
     "no-arg": true,
     "no-bitwise": false,


### PR DESCRIPTION
## このpull requestが解決する内容

akashic-engine@2 系に追従します。

- Trigger の追従
- テスト用g.Gameモックの更新
- sample の更新
- その他文書で目についた箇所を校正、細かなインデント崩れの修正など
- ついでに deprecated 扱いになっていた `bitmapFont`, `rubyBitmapFont` を削除

akashic-engine とのバージョン間の関係がわかりやすいように、このライブラリも v2 (2.0.0) にしてしまっています。(現行の v1 系用を、次の publish で v1.0.0 にしてしまう想定)

## 破壊的な変更を含んでいるか？

YES. akashic-engine@2 系を前提にするようになります。
1系は v1-master ブランチで保守します。