### PR TITLE
bump dependencies version

### DIFF
--- a/sample/game/package.json
+++ b/sample/game/package.json
@@ -8,6 +8,6 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "@akashic-extension/akashic-label": "2.0.0"
+    "@akashic-extension/akashic-label": "2.0.1"
   }
 }

--- a/sample/package.json
+++ b/sample/package.json
@@ -22,7 +22,7 @@
     "tslint": "^5.4.3"
   },
   "dependencies": {
-    "@akashic-extension/akashic-label": "2.0.0",
+    "@akashic-extension/akashic-label": "2.0.1",
     "@akashic/akashic-cli": "~1.3.0",
     "@akashic/akashic-sandbox": "^0.13.7"
   }


### PR DESCRIPTION
掲題の通りです。
https://github.com/akashic-games/akashic-label/pull/13 の作業漏れ修正です。