### PR TITLE
[sample]use grapheme-splitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-label",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "text library for akashic",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/akashic-engine": "~2.1.2",
-    "grapheme-splitter": "^1.0.4"
+    "@akashic/akashic-engine": "~2.1.2"
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/akashic-engine": "~2.1.2"
+    "@akashic/akashic-engine": "~2.1.2",
+    "grapheme-splitter": "^1.0.4"
   },
   "files": [
     "lib",

--- a/sample/game.json
+++ b/sample/game.json
@@ -55,14 +55,18 @@
 		}
 	},
 	"globalScripts": [
-		"node_modules/@akashic-extension/akashic-label/lib/Label.js",
 		"node_modules/@akashic-extension/akashic-label/lib/DefaultRubyParser.js",
-		"node_modules/@akashic-extension/akashic-label/lib/RubyParser.js",
 		"node_modules/@akashic-extension/akashic-label/lib/FragmentDrawInfo.js",
+		"node_modules/@akashic-extension/akashic-label/lib/Label.js",
+		"node_modules/@akashic-extension/akashic-label/lib/RubyParser.js",
 		"node_modules/@akashic-extension/akashic-label/lib/index.js",
-		"node_modules/@akashic-extension/akashic-label/package.json"
+		"node_modules/grapheme-splitter/index.js"
 	],
 	"environment": {
 		"sandbox-runtime": "2"
+	},
+	"moduleMainScripts": {
+		"@akashic-extension/akashic-label": "node_modules/@akashic-extension/akashic-label/lib/index.js",
+		"grapheme-splitter": "node_modules/grapheme-splitter/index.js"
 	}
 }

--- a/sample/package.json
+++ b/sample/package.json
@@ -24,6 +24,7 @@
     "tslint": "^5.4.3"
   },
   "dependencies": {
-    "@akashic-extension/akashic-label": "2.0.3"
+    "@akashic-extension/akashic-label": "2.0.5",
+    "grapheme-splitter": "~1.0.4"
   }
 }

--- a/sample/src/mainScene.ts
+++ b/sample/src/mainScene.ts
@@ -1,7 +1,7 @@
 import {Label} from "@akashic-extension/akashic-label";
 import graphemeSplitter = require("grapheme-splitter");
-var splitter = new graphemeSplitter();
 
+var splitter = new graphemeSplitter();
 var game = g.game;
 
 export = function() {

--- a/sample/src/mainScene.ts
+++ b/sample/src/mainScene.ts
@@ -1,4 +1,7 @@
 import {Label} from "@akashic-extension/akashic-label";
+import graphemeSplitter = require("grapheme-splitter");
+var splitter = new graphemeSplitter();
+
 var game = g.game;
 
 export = function() {
@@ -198,7 +201,7 @@ export = function() {
 			fontSize: 20,
 			width: 100
 		});
-		label23.x = 150;
+		label23.x = 100;
 		label23.y = y2 + 50;;
 		scene.append(label23);
 		label23.update.add(function(){
@@ -227,6 +230,20 @@ export = function() {
 			}
 		}, label24);
 		scene.append(label24);
+
+		// grapheme clusterの利用
+		var counter25 = 0;
+		var label25 = new Label({
+			scene: scene,
+			text: "unicode😭\r👨🏿‍👩‍👧‍👦",
+			font: mplusfont,
+			fontSize: 20,
+			width: 100,
+			textSplitter: splitter.splitGraphemes.bind(splitter)
+		});
+		label25.x = 210;
+		label25.y = y2 + 50;;
+		scene.append(label25);
 
 		var nlabel = new Label({
 			scene: scene,

--- a/spec/helpers/mock.ts
+++ b/spec/helpers/mock.ts
@@ -170,6 +170,14 @@ export class Renderer extends g.Renderer {
 		});
 	}
 
+	setShaderProgram(shaderProgram: g.ShaderProgram): void {
+		// do nothing
+	}
+
+	isSupportedShaderProgram(): boolean {
+		return false;
+	}
+
 	_getImageData(sx: number, sy: number, sw: number, sh: number): g.ImageData {
 		this.methodCallHistoryWithParams.push({
 			methodName: "_getImageData"
@@ -511,6 +519,10 @@ export class Game extends g.Game {
 
 	saveSnapshot(snapshot: any): void {
 		// do nothing.
+	}
+
+	getCurrentTime(): number {
+		return 0;
 	}
 
 	addEventFilter(filter: g.EventFilter): void {

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -810,7 +810,7 @@ class Label extends g.CacheableE {
 	}
 }
 
-function defaultTextSplitter(text: string) {
+function defaultTextSplitter(text: string): string[] {
 	return text.replace(/\r\n|\n/g, "\r").match(/[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\uD800-\uDFFF]/g);
 }
 

--- a/src/LabelParameterObject.ts
+++ b/src/LabelParameterObject.ts
@@ -98,6 +98,13 @@ interface LabelParameterObject extends g.CacheableEParameterObject {
 	 *
 	 */
 	lineBreakRule?: rt.LineBreakRule;
+
+	/**
+	 * textを一文字単位に分割するパーサ。
+	 * 初期値は サロゲートペアの分割に対応した関数である。
+	 * grapheme clusterなどを考慮した高度な分割を行いたい場合、この値に適切な関数を指定する必要がある。
+	 */
+	textSplitter?: (text: string) => string[];
 }
 
 export = LabelParameterObject;

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,0 +1,7 @@
+import graphemeSplitter = require("grapheme-splitter");
+
+var splitter = new graphemeSplitter();
+
+export function splitToGraphemes(str: string): string[] {
+	return splitter.splitGraphemes(str);
+}

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,7 +1,0 @@
-import graphemeSplitter = require("grapheme-splitter");
-
-var splitter = new graphemeSplitter();
-
-export function splitToGraphemes(str: string): string[] {
-	return splitter.splitGraphemes(str);
-}


### PR DESCRIPTION
## このpull requestが解決する内容

grapheme cluster（例： 👨‍👩‍👧‍👦  ）を正しく描画できない問題に対する解決案の提案です。
grapheme-splitterを利用してZWJやskintoneを正しくパースします。

動作には https://github.com/akashic-games/akashic-engine/pull/99 に対応した内部モジュールの更新が必要です。

## 破壊的な変更を含んでいるか？

なし
