### PR TITLE
fix uncaught type error being thrown when ruby is disabled and text is empty

### DIFF
--- a/spec/LabelSpec.js
+++ b/spec/LabelSpec.js
@@ -119,6 +119,19 @@ describe("test Label", function() {
 		}).toThrowError("AssertionError");
 	});
 
+	it("初期化 - ルビ無効かつ空テキスト", function() {
+		expect( function() {
+			new Label({
+				scene: runtime.scene,
+				text: "",
+				font: bmpfont,
+				fontSize: 20,
+				width: 300,
+				rubyEnabled: false
+			});
+		}).not.toThrowError("TypeError");
+	});
+
 	it("render", function(){
 		var mlabel = new Label({
 			scene: runtime.scene,

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -342,7 +342,7 @@ class Label extends g.CacheableE {
 			rp.flatmap<rp.Fragment, rp.Fragment>(fragments, (f) => {
 				if (typeof f !== "string") return f;
 				// サロゲートペア文字を正しく分割する
-				return f.replace(/\r\n|\n/g, "\r").match(/[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\uD800-\uDFFF]/g);
+				return f.replace(/\r\n|\n/g, "\r").match(/[\uD800-\uDBFF][\uDC00-\uDFFF]|[^\uD800-\uDFFF]/g) || [];
 			});
 
 		var undrawnLineInfos = this._divideToLines(fragments);


### PR DESCRIPTION
rubyEnabledがfalseのときにtextに空文字列を入れると `Uncaught TypeError: Cannot read property 'rb' of null` というエラーが発生してしまう問題を見つけたため修正しました。

発生箇所は[こちら](https://github.com/akashic-games/akashic-label/blob/6f61a7d0d0c95d75412641147ff929a55f0758d9/src/Label.ts#L634)で、 文字列のfragmentを分解する処理中にnullのfragmentが作られることが原因です。
String.prototype.match()は[マッチしない場合にnullを返す](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/match#%E8%BF%94%E3%82%8A%E5%80%A4)ため、その場合は空配列を返す挙動になるように変更しました。