### PR TITLE
LabelのtextAlign 指定時に g.TextAlignString 型を指定できるようにした

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.0.0-beta.2
+
+* textAlign 指定時に `g.TextAlignString` 型を指定できるようにした
+* akashic-engine@3.0.0-beta.33 に追従
+
 ## 3.0.0-beta.1
 
 * akashic-engine@3.0.0-beta.28 に追従

--- a/akashic-label.md
+++ b/akashic-label.md
@@ -209,7 +209,7 @@ var label = new Label({
     text: text,
     font: font,
     fontSize: 15,
-    textAlign: g.TextAlign.Left,
+    textAlign: "left",
     width: game.width,
     lineBreak: true,
     lineBreakRule: sampleRule

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/akashic-label",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "text library for akashic",
   "main": "lib/index.js",
   "scripts": {
@@ -33,7 +33,7 @@
   },
   "typings": "lib/index.d.ts",
   "dependencies": {
-    "@akashic/akashic-engine": "~3.0.0-beta.28"
+    "@akashic/akashic-engine": "~3.0.0-beta.33"
   },
   "files": [
     "lib",

--- a/sample/package.json
+++ b/sample/package.json
@@ -14,16 +14,16 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@types/node": "6.0.46",
-    "@akashic/akashic-engine": "~3.0.0-beta.28",
     "@akashic/akashic-cli": "~1.3.0",
+    "@akashic/akashic-engine": "~3.0.0-beta.33",
     "@akashic/akashic-sandbox": "^0.16.0",
-    "jasmine": "^2.1.1",
+    "@types/node": "6.0.46",
     "istanbul": "^0.3.2",
+    "jasmine": "^2.1.1",
     "tslint": "^5.4.3",
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@akashic-extension/akashic-label": "~3.0.0-beta.1"
+    "@akashic-extension/akashic-label": "file:../akashic-extension-akashic-label-3.0.0-beta.2.tgz"
   }
 }

--- a/sample/package.json
+++ b/sample/package.json
@@ -24,6 +24,6 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@akashic-extension/akashic-label": "file:../akashic-extension-akashic-label-3.0.0-beta.2.tgz"
+    "@akashic-extension/akashic-label": "~3.0.0-beta.2"
   }
 }

--- a/sample/src/mainScene.ts
+++ b/sample/src/mainScene.ts
@@ -8,7 +8,7 @@ export function mainScene(): g.Scene {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 3;
-	scene.loaded.add(() => {
+	scene.onLoad.add(() => {
 
 		// グリフデータの生成
 		var mPlusGlyphInfo = JSON.parse(scene.asset.getTextById("mplus-glyph").data);
@@ -27,7 +27,7 @@ export function mainScene(): g.Scene {
 		};
 		var dfont = new g.DynamicFont({
 			game: scene.game,
-			fontFamily: g.FontFamily.Monospace,
+			fontFamily: "monospace",
 			size: 40,
 			hint: dhint
 		});
@@ -39,7 +39,7 @@ export function mainScene(): g.Scene {
 			font: mplusfont,
 			fontSize: 30,
 			width: game.width,
-			textAlign: g.TextAlign.Center
+			textAlign: "center"
 		});
 		tlabel0.x = 0;
 		scene.append(tlabel0);
@@ -71,7 +71,7 @@ export function mainScene(): g.Scene {
 		label02.x = game.width / 4;
 		label02.y = y0;
 		label02.touchable = true;
-		label02.update.add(() => {
+		label02.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label02.textColor = colors[counter02 % colors.length];
 				counter02++;
@@ -92,7 +92,7 @@ export function mainScene(): g.Scene {
 		label03.x = game.width / 4 * 2;
 		label03.y = y0;
 		label03.touchable = true;
-		label03.update.add(() => {
+		label03.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label03.fontSize = (counter03 % 6) * 3 + 5;
 				counter03++;
@@ -111,7 +111,7 @@ export function mainScene(): g.Scene {
 			font: mplusfont,
 			fontSize: 20,
 			width: game.width,
-			textAlign: g.TextAlign.Left
+			textAlign: "left"
 		});
 		label11.y = y1;
 		scene.append(label11);
@@ -123,7 +123,7 @@ export function mainScene(): g.Scene {
 			font: mplusfont,
 			fontSize: 20,
 			width: game.width,
-			textAlign: g.TextAlign.Center
+			textAlign: "center"
 		});
 		label12.y = y1;
 		scene.append(label12);
@@ -135,7 +135,7 @@ export function mainScene(): g.Scene {
 			font: mplusfont,
 			fontSize: 20,
 			width: game.width,
-			textAlign: g.TextAlign.Right
+			textAlign: "right"
 		});
 		label12.y = y1;
 		scene.append(label12);
@@ -145,7 +145,7 @@ export function mainScene(): g.Scene {
 
 		// 複数行のラベル
 		var counter21 = 0;
-		var aligns21 =  [g.TextAlign.Left, g.TextAlign.Center, g.TextAlign.Right];
+		var aligns21: g.TextAlignString[] =  ["left", "center", "right"];
 		var label21 = new Label({
 			scene: scene,
 			text: "改行記号（￥ｒ・￥ｎ・￥ｒ￥ｎ）\rで改行できます",
@@ -155,7 +155,7 @@ export function mainScene(): g.Scene {
 		});
 		label21.y = y2;
 		scene.append(label21);
-		label21.update.add(() => {
+		label21.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label21.textAlign = aligns21[counter21 % 3];
 				counter21++;
@@ -175,7 +175,7 @@ export function mainScene(): g.Scene {
 		});
 		label22.y = y2 + 50;
 		label22.touchable = true;
-		label22.update.add(() => {
+		label22.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label22.lineGap = Math.round(counter22 % 10) - 5;
 				counter22++;
@@ -196,7 +196,7 @@ export function mainScene(): g.Scene {
 		label23.x = 150;
 		label23.y = y2 + 50;
 		scene.append(label23);
-		label23.update.add(() => {
+		label23.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label23.width = counter23 % 10 * 10 + 100;
 				counter23++;
@@ -215,7 +215,7 @@ export function mainScene(): g.Scene {
 		});
 		label24.y = y2 + 150;
 		label24.touchable = true;
-		label24.update.add(() => {
+		label24.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label24.lineBreak = !label24.lineBreak;
 				label24.invalidate();
@@ -233,7 +233,7 @@ export function mainScene(): g.Scene {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.add(() => {
+		nlabel.onPointDown.add(() => {
 			var scene2 = mainScene2();
 			game.replaceScene(scene2);
 		}, nlabel);
@@ -244,19 +244,19 @@ export function mainScene(): g.Scene {
 			text: "［フォント切替］",
 			font: mplusfont,
 			fontSize: 20,
-			textAlign: g.TextAlign.Right,
+			textAlign: "right",
 			width: 130
 		});
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.add(() => {
+		dlabel.onPointDown.add(() => {
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;
 					label.rubyOptions.rubyFont = new g.DynamicFont({
 						game: scene.game,
-						fontFamily: g.FontFamily.Monospace,
+						fontFamily: "monospace",
 						size: 40
 					});
 					label.invalidate();

--- a/sample/src/mainScene2.ts
+++ b/sample/src/mainScene2.ts
@@ -8,7 +8,7 @@ export function mainScene2(): g.Scene {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 6;
-	scene.loaded.add(() => {
+	scene.onLoad.add(() => {
 
 		// グリフデータの生成
 		var mPlusGlyphInfo = JSON.parse(scene.asset.getTextById("mplus-glyph").data);
@@ -33,7 +33,7 @@ export function mainScene2(): g.Scene {
 		};
 		var dfont = new g.DynamicFont({
 			game: scene.game,
-			fontFamily: g.FontFamily.Monospace,
+			fontFamily: "monospace",
 			size: 40,
 			hint: dhint
 		});
@@ -45,7 +45,7 @@ export function mainScene2(): g.Scene {
 			font: mplusfont,
 			fontSize: 30,
 			width: game.width,
-			textAlign: g.TextAlign.Center
+			textAlign: "center"
 		});
 		tlabel0.x = 0;
 		scene.append(tlabel0);
@@ -88,7 +88,7 @@ export function mainScene2(): g.Scene {
 		label03.x = 0;
 		label03.y = y0 + 90;
 		label03.touchable = true;
-		label03.update.add(() => {
+		label03.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label03.rubyOptions.rubyGap = counter03 % 4 - 5;
 				counter03++;
@@ -111,7 +111,7 @@ export function mainScene2(): g.Scene {
 		label04.y = y0 + 90;
 		label04.touchable = true;
 		scene.append(label04);
-		label04.update.add(() => {
+		label04.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label04.rubyOptions.rubyFontSize = counter04 % 5 + 15;
 				counter04++;
@@ -132,7 +132,7 @@ export function mainScene2(): g.Scene {
 		label05.y = y0 + 90;
 		label05.touchable = true;
 		scene.append(label05);
-		label05.update.add(() => {
+		label05.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				if (label05.rubyOptions.rubyFont === bmpfont) {
 					label05.rubyOptions.rubyFont = mplusfont;
@@ -178,7 +178,7 @@ export function mainScene2(): g.Scene {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.add(() => {
+		nlabel.onPointDown.add(() => {
 			var scene3 = mainScene3();
 			game.replaceScene(scene3);
 		}, nlabel);
@@ -188,13 +188,13 @@ export function mainScene2(): g.Scene {
 			text: "［フォント切替］",
 			font: mplusfont,
 			fontSize: 20,
-			textAlign: g.TextAlign.Right,
+			textAlign: "right",
 			width: 130
 		});
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.add(() => {
+		dlabel.onPointDown.add(() => {
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;

--- a/sample/src/mainScene3.ts
+++ b/sample/src/mainScene3.ts
@@ -7,7 +7,7 @@ export function mainScene3(): g.Scene {
 		game: game,
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
-	scene.loaded.add(() => {
+	scene.onLoad.add(() => {
 
 		// グリフデータの生成
 		var mPlusGlyphInfo = JSON.parse(scene.asset.getTextById("mplus-glyph").data);
@@ -26,7 +26,7 @@ export function mainScene3(): g.Scene {
 		};
 		var dfont = new g.DynamicFont({
 			game: scene.game,
-			fontFamily: g.FontFamily.Monospace,
+			fontFamily: "monospace",
 			size: 40,
 			hint: dhint
 		});
@@ -38,7 +38,7 @@ export function mainScene3(): g.Scene {
 			font: mplusfont,
 			fontSize: 31,
 			width: game.width,
-			textAlign: g.TextAlign.Center
+			textAlign: "center"
 		});
 		tlabel0.x = 0;
 		scene.append(tlabel0);
@@ -111,7 +111,7 @@ export function mainScene3(): g.Scene {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.add(() => {
+		nlabel.onPointDown.add(() => {
 			var scene3 = mainScene4();
 			game.replaceScene(scene3);
 		}, nlabel);
@@ -121,13 +121,13 @@ export function mainScene3(): g.Scene {
 			text: "［フォント切替］",
 			font: mplusfont,
 			fontSize: 20,
-			textAlign: g.TextAlign.Right,
+			textAlign: "right",
 			width: 130
 		});
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.add(() => {
+		dlabel.onPointDown.add(() => {
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;

--- a/sample/src/mainScene4.ts
+++ b/sample/src/mainScene4.ts
@@ -8,7 +8,7 @@ export function mainScene4(): g.Scene {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 3;
-	scene.loaded.add(() => {
+	scene.onLoad.add(() => {
 
 		// グリフデータの生成
 		var mPlusGlyphInfo = JSON.parse(scene.asset.getTextById("mplus-glyph").data);
@@ -33,7 +33,7 @@ export function mainScene4(): g.Scene {
 		};
 		var dfont = new g.DynamicFont({
 			game: scene.game,
-			fontFamily: g.FontFamily.Monospace,
+			fontFamily: "monospace",
 			size: 40,
 			hint: dhint
 		});
@@ -45,7 +45,7 @@ export function mainScene4(): g.Scene {
 			font: mplusfont,
 			fontSize: 30,
 			width: game.width,
-			textAlign: g.TextAlign.Center
+			textAlign: "center"
 		});
 		tlabel0.x = 0;
 		scene.append(tlabel0);
@@ -98,7 +98,7 @@ export function mainScene4(): g.Scene {
 		label00.x = 0;
 		label00.y = y0;
 		scene.append(label00);
-		label00.update.add(() => {
+		label00.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label00.width = counter00 % 20 * 10 + 120;
 				counter00++;
@@ -140,7 +140,7 @@ export function mainScene4(): g.Scene {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.add(() => {
+		nlabel.onPointDown.add(() => {
 			var scene3 = mainScene5();
 			game.replaceScene(scene3);
 		}, nlabel);
@@ -151,13 +151,13 @@ export function mainScene4(): g.Scene {
 			text: "［フォント切替］",
 			font: mplusfont,
 			fontSize: 20,
-			textAlign: g.TextAlign.Right,
+			textAlign: "right",
 			width: 130
 		});
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.add(() => {
+		dlabel.onPointDown.add(() => {
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;

--- a/sample/src/mainScene5.ts
+++ b/sample/src/mainScene5.ts
@@ -8,7 +8,7 @@ export function mainScene5(): g.Scene {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 2;
-	scene.loaded.add(() => {
+	scene.onLoad.add(() => {
 
 		// グリフデータの生成
 		var mPlusGlyphInfo = JSON.parse(scene.asset.getTextById("mplus-glyph").data);
@@ -33,7 +33,7 @@ export function mainScene5(): g.Scene {
 		};
 		var dfont = new g.DynamicFont({
 			game: scene.game,
-			fontFamily: g.FontFamily.Monospace,
+			fontFamily: "monospace",
 			size: 40,
 			hint: dhint
 		});
@@ -45,7 +45,7 @@ export function mainScene5(): g.Scene {
 			font: mplusfont,
 			fontSize: 30,
 			width: game.width,
-			textAlign: g.TextAlign.Center
+			textAlign: "center"
 		});
 		tlabel0.x = 0;
 		scene.append(tlabel0);
@@ -65,7 +65,7 @@ export function mainScene5(): g.Scene {
 		});
 		label01.y = y0;
 		label01.touchable = true;
-		label01.update.add(() => {
+		label01.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				label01.fixLineGap = !label01.fixLineGap;
 				label01.invalidate();
@@ -122,9 +122,9 @@ export function mainScene5(): g.Scene {
 		});
 		mlabel.y = 130;
 		counter = 0;
-		mlabel.textAlign = g.TextAlign.Left;
+		mlabel.textAlign = "left";
 		scene.append(mlabel);
-		mlabel.update.add(() => {
+		mlabel.onUpdate.add(() => {
 			// 初期化と待機
 			if (counter === textArray.length) {
 				mlabel.text = "";
@@ -153,13 +153,13 @@ export function mainScene5(): g.Scene {
 			text: "［フォント切替］",
 			font: mplusfont,
 			fontSize: 20,
-			textAlign: g.TextAlign.Right,
+			textAlign: "right",
 			width: 130
 		});
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.add(() => {
+		dlabel.onPointDown.add(() => {
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;
@@ -181,7 +181,7 @@ export function mainScene5(): g.Scene {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.add(() => {
+		nlabel.onPointDown.add(() => {
 			var scene3 = mainScene6();
 			game.replaceScene(scene3);
 		}, nlabel);
@@ -192,13 +192,13 @@ export function mainScene5(): g.Scene {
 			text: "［フォント切替］",
 			font: mplusfont,
 			fontSize: 20,
-			textAlign: g.TextAlign.Right,
+			textAlign: "right",
 			width: 130
 		});
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.add(() => {
+		dlabel.onPointDown.add(() => {
 			scene.children.forEach((child: g.E) => {
 				if (child instanceof Label) {
 					child.font = dfont;

--- a/sample/src/mainScene6.ts
+++ b/sample/src/mainScene6.ts
@@ -9,7 +9,7 @@ export function mainScene6(): g.Scene {
 		assetIds: ["bmpfont", "bmpfont-glyph", "mplus", "mplus-glyph"]
 	});
 	var rate = game.fps / 2;
-	scene.loaded.add(() => {
+	scene.onLoad.add(() => {
 
 		// グリフデータの生成
 		var mPlusGlyphInfo = JSON.parse(scene.asset.getTextById("mplus-glyph").data);
@@ -28,7 +28,7 @@ export function mainScene6(): g.Scene {
 		};
 		var dfont = new g.DynamicFont({
 			game: scene.game,
-			fontFamily: g.FontFamily.Monospace,
+			fontFamily: "monospace",
 			size: 40,
 			hint: dhint
 		});
@@ -39,7 +39,7 @@ export function mainScene6(): g.Scene {
 			font: mplusfont,
 			fontSize: 30,
 			width: game.width,
-			textAlign: g.TextAlign.Center
+			textAlign: "center"
 		});
 		tlabel0.x = 0;
 		scene.append(tlabel0);
@@ -71,14 +71,14 @@ export function mainScene6(): g.Scene {
 			text: text,
 			font: mplusfont,
 			fontSize: 15,
-			textAlign: g.TextAlign.Left,
+			textAlign: "left",
 			width: game.width / 4,
 			lineBreak: true,
 			lineBreakRule: sampleRule
 		});
 		lblabel.y = 40;
 		scene.append(lblabel);
-		lblabel.update.add(() => {
+		lblabel.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				lblabel.width += 5;
 				if (lblabel.width > game.width) lblabel.width = 100;
@@ -109,7 +109,7 @@ export function mainScene6(): g.Scene {
 			text: text,
 			font: mplusfont,
 			fontSize: 15,
-			textAlign: g.TextAlign.Left,
+			textAlign: "left",
 			width: game.width / 4,
 			lineBreak: true,
 			widthAutoAdjust: true,
@@ -117,7 +117,7 @@ export function mainScene6(): g.Scene {
 		});
 		lblabel2.y = 190;
 		scene.append(lblabel2);
-		lblabel2.update.add(() => {
+		lblabel2.onUpdate.add(() => {
 			if (game.age % rate === 0) {
 				lblabel2.width = counter % 20 * 5 + 120;
 				counter++;
@@ -135,7 +135,7 @@ export function mainScene6(): g.Scene {
 		nlabel.x = 230;
 		nlabel.y = game.height - 20;
 		nlabel.touchable = true;
-		nlabel.pointDown.add(() => {
+		nlabel.onPointDown.add(() => {
 			var scene3 = mainScene();
 			game.replaceScene(scene3);
 		}, nlabel);
@@ -146,13 +146,13 @@ export function mainScene6(): g.Scene {
 			text: "［フォント切替］",
 			font: mplusfont,
 			fontSize: 20,
-			textAlign: g.TextAlign.Right,
+			textAlign: "right",
 			width: 130
 		});
 		dlabel.x = 100;
 		dlabel.y = game.height - 20;
 		dlabel.touchable = true;
-		dlabel.pointDown.add(() => {
+		dlabel.onPointDown.add(() => {
 			scene.children.forEach((label) => {
 				if (label instanceof Label) {
 					label.font = dfont;

--- a/spec/LabelSpec.js
+++ b/spec/LabelSpec.js
@@ -66,7 +66,7 @@ describe("test Label", function() {
 		expect(mlabel.text).toBe("foo");
 		expect(mlabel.font).toBe(bmpfont);
 		expect(mlabel.width).toBe(300);
-		expect(mlabel.textAlign).toBe(g.TextAlign.Left);
+		expect(mlabel.textAlign).toBe("left");
 		expect(mlabel.fontSize).toBe(20);
 		expect(mlabel.lineGap).toBe(0);
 		expect(mlabel.lineBreak).toBe(true);
@@ -85,7 +85,7 @@ describe("test Label", function() {
 				width: 200,
 				lineBreak: false,
 				lineGap: 2,
-				textAlign: g.TextAlign.Center
+				textAlign: "center"
 			});
 		}).toThrowError("AssertionError");
 	});
@@ -100,7 +100,7 @@ describe("test Label", function() {
 				width: 200,
 				lineBreak: false,
 				lineGap: -11,
-				textAlign: g.TextAlign.Right
+				textAlign: "right"
 			});
 		}).toThrowError("AssertionError");
 	});
@@ -114,7 +114,7 @@ describe("test Label", function() {
 				width: 200,
 				lineBreak: false,
 				lineGap: -11,
-				textAlign: g.TextAlign.Right
+				textAlign: "right"
 			});
 		}).toThrowError("AssertionError");
 	});
@@ -222,9 +222,9 @@ describe("test Label", function() {
 		});
 
 		expect(mlabel._offsetX(fontSize)).toBe(0);
-		mlabel.textAlign = g.TextAlign.Center;
+		mlabel.textAlign = "center";
 		expect(mlabel._offsetX(fontSize)).toBe(45); // (100 - 10) / 2
-		mlabel.textAlign = g.TextAlign.Right;
+		mlabel.textAlign = "right";
 		expect(mlabel._offsetX(fontSize)).toBe(90); // 100 - 10
 	});
 
@@ -235,7 +235,7 @@ describe("test Label", function() {
 			font: bmpfont,
 			textColor: "black",
 			fontSize: 10,
-			textAlign: g.TextAlign.Center,
+			textAlign: "center",
 			width: 100,
 			lineBreak: true,
 			lineGap: 2
@@ -243,7 +243,7 @@ describe("test Label", function() {
 		mlabel.text = "b";
 		mlabel.textColor = "red";
 		mlabel.fontSize = 15;
-		mlabel.textAlign = g.TextAlign.Right;
+		mlabel.textAlign = "right";
 		mlabel.width = 200;
 		mlabel.lineBreak = false;
 		mlabel.lineGap = 3;
@@ -260,7 +260,7 @@ describe("test Label", function() {
 			textColor: "red",
 			font: bmpfont,
 			fontSize: 15,
-			textAlign: g.TextAlign.Right,
+			textAlign: "right",
 			width: 200,
 			lineBreak: false,
 			lineGap: 3,
@@ -606,7 +606,7 @@ describe("test Label", function() {
 			var mlabel = new Label({
 				scene: runtime.scene,
 				text: text,
-				textAlign:  g.TextAlign.Left,
+				textAlign:  "left",
 				font: bmpfont,
 				fontSize: 10,
 				width: 105,
@@ -676,7 +676,7 @@ describe("test Label", function() {
 			var mlabel = new Label({
 				scene: runtime.scene,
 				text: text,
-				textAlign: g.TextAlign.Left,
+				textAlign: "left",
 				font: bmpfont,
 				fontSize: 10,
 				width: 105,
@@ -714,7 +714,7 @@ describe("test Label", function() {
 			var mlabel = new Label({
 				scene: runtime.scene,
 				text: text,
-				textAlign: g.TextAlign.Left,
+				textAlign: "left",
 				font: bmpfont,
 				fontSize: 10,
 				width: 105,
@@ -786,7 +786,7 @@ describe("test Label", function() {
 				width: 100,
 				lineBreak: false,
 				lineGap: 2,
-				textAlign: g.TextAlign.Left,
+				textAlign: "left",
 				lineBreakRule: (fragments, index) => index
 			});
 			expect(mlabel.lineBreakRule).toEqual((fragments, index) => index);
@@ -802,7 +802,7 @@ describe("test Label", function() {
 			width: 30,
 			lineBreak: true,
 			lineGap: 2,
-			textAlign: g.TextAlign.Left,
+			textAlign: "left",
 			lineBreakRule: (fragments, index) => {
 				if (fragments[index] === "3") {
 					return index - 1;
@@ -825,7 +825,7 @@ describe("test Label", function() {
 			width: 30,
 			lineBreak: true,
 			lineGap: 2,
-			textAlign: g.TextAlign.Left,
+			textAlign: "left",
 			lineBreakRule: (fragments, index) => {
 				if (fragments[index] === "3") {
 					return index + 1;
@@ -849,7 +849,7 @@ describe("test Label", function() {
 			width: 80,
 			lineBreak: true,
 			lineGap: 2,
-			textAlign: g.TextAlign.Left,
+			textAlign: "left",
 			lineBreakRule: (fragments, index) => {
 				if (fragments[index] === "]") {
 					return index + 1; // 先送り改行

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -270,13 +270,13 @@ class Label extends g.CacheableE {
 	_offsetX(width: number): number {
 		switch (this.textAlign) {
 			case "left":
-			case "left":
+			case g.TextAlign.Left:
 				return 0;
 			case "right":
-			case "right":
+			case g.TextAlign.Right:
 				return (this._lineBreakWidth - width);
 			case "center":
-			case "center":
+			case g.TextAlign.Center:
 				return ((this._lineBreakWidth - width) / 2);
 			default:
 				return 0;

--- a/src/Label.ts
+++ b/src/Label.ts
@@ -43,10 +43,10 @@ class Label extends g.CacheableE {
 
 	/**
 	 * 文字列の描画位置。
-	 * 初期値は `g.TextAlign.Left` である。
+	 * 初期値は `"left"` である。
 	 * この値を変更した場合、 `this.invalidate()` を呼び出す必要がある。
 	 */
-	textAlign: g.TextAlign;
+	textAlign: g.TextAlign | g.TextAlignString;
 
 	/**
 	 * フォントサイズ。
@@ -102,8 +102,8 @@ class Label extends g.CacheableE {
 	/**
 	 * `width` プロパティを `this.text` の描画に必要な幅の値に自動的に更新するかを表す。
 	 * `width` プロパティの更新は `this.invalidate()` を呼び出した後のタイミングで行われる。
-	 * `textAlign` を `TextAlign.Left` 以外にする場合、この値は `false` にすべきである。
-	 * `textAlign` が `TextAlign.Left` 以外かつ、 この値が `true` の場合、描画内容は不定である。
+	 * `textAlign` を `"left"` 以外にする場合、この値は `false` にすべきである。
+	 * `textAlign` が `"left"` 以外かつ、 この値が `true` の場合、描画内容は不定である。
 	 * 初期値は偽である。
 	 * この値を変更した場合、 `this.invalidate()` を呼び出す必要がある。
 	 */
@@ -139,7 +139,7 @@ class Label extends g.CacheableE {
 	_beforeFont: g.Font;
 	_beforeLineBreak: boolean;
 	_beforeFontSize: number;
-	_beforeTextAlign: g.TextAlign;
+	_beforeTextAlign: g.TextAlign | g.TextAlignString;
 	_beforeWidth: number;
 	_beforeRubyEnabled: boolean;
 	_beforeFixLineGap: boolean;
@@ -169,7 +169,7 @@ class Label extends g.CacheableE {
 		this._lineBreakWidth = param.width;
 		this.lineBreak = "lineBreak" in param ? param.lineBreak : true;
 		this.lineGap = param.lineGap || 0;
-		this.textAlign = "textAlign" in param ? param.textAlign : g.TextAlign.Left;
+		this.textAlign = "textAlign" in param ? param.textAlign : "left";
 		this.textColor = param.textColor;
 		this.trimMarginTop = "trimMarginTop" in param ? param.trimMarginTop : false;
 		this.widthAutoAdjust = "widthAutoAdjust" in param ? param.widthAutoAdjust : false;
@@ -250,7 +250,7 @@ class Label extends g.CacheableE {
 	 * 禁則処理によって行幅が this.width を超える場合があるため、 `g.CacheableE` のメソッドをオーバーライドする
 	 */
 	calculateCacheSize(): g.CommonSize {
-		// TODO: 最大値の候補に this.width を使用するのは textAlign が g.Center か g.Right の場合に描画に必要なキャッシュサイズを確保するためであり、
+		// TODO: 最大値の候補に this.width を使用するのは textAlign が "center" か "right" の場合に描画に必要なキャッシュサイズを確保するためであり、
 		// 最大行幅に対して this.width が大きい場合、余分なキャッシュ領域を確保することになる。
 		// これは g.CacheableE にキャッシュ描画位置を調整する cacheOffsetX を導入することで解決される。
 		const maxWidth = Math.ceil(this._lines.reduce((width: number, line: fr.LineInfo) => Math.max(width, line.width), this.width));
@@ -269,11 +269,14 @@ class Label extends g.CacheableE {
 
 	_offsetX(width: number): number {
 		switch (this.textAlign) {
-			case g.TextAlign.Left:
+			case "left":
+			case "left":
 				return 0;
-			case g.TextAlign.Right:
+			case "right":
+			case "right":
 				return (this._lineBreakWidth - width);
-			case g.TextAlign.Center:
+			case "center":
+			case "center":
 				return ((this._lineBreakWidth - width) / 2);
 			default:
 				return 0;

--- a/src/LabelParameterObject.ts
+++ b/src/LabelParameterObject.ts
@@ -43,9 +43,9 @@ interface LabelParameterObject extends g.CacheableEParameterObject {
 
 	/**
 	 * 文字列の描画位置。
-	 * 初期値は `g.TextAlign.Left` である。
+	 * 初期値は `"left"` である。
 	 */
-	textAlign?: g.TextAlign;
+	textAlign?: g.TextAlign | g.TextAlignString;
 
 	/**
 	 * 文字列の描画色をCSS Color形式で指定する。
@@ -75,7 +75,7 @@ interface LabelParameterObject extends g.CacheableEParameterObject {
 
 	/**
 	 * `width` プロパティを `this.text` の描画に必要な幅で自動的に更新するかを表す。
-	 * `textAlign` を `TextAlign.Left` 以外にする場合、この値は `false` にすべきである。
+	 * `textAlign` を `"left"` 以外にする場合、この値は `false` にすべきである。
 	 * (`textAlign` は `width` を元に描画位置を調整するため、 `true` の場合左寄せで右寄せでも描画結果が変わらなくなる)
 	 * 初期値は偽である。
 	 */


### PR DESCRIPTION
### 概要
v3系に対応しているにも関わらずv3の機能が利用できない箇所があったので修正しました。該当箇所は「LabelのtextAlign 指定時に g.TextAlignString 型が指定できない」のみだったのでライブラリの修正は結果的にそこだけとなりました。
また、サンプルコンテンツでもなるべくv3の機能を利用するように修正しました。

### やったこと
* LabelのtextAlign 指定時に g.TextAlign だけでなく g.TextAlignString も指定できるようにした
* 依存するakashic-engineのバージョンを最新のものに更新
* サンプルコンテンツでv3系の型やメソッドを利用するように修正