### PR TITLE
Fix sample

### DIFF
--- a/sample/src/mainScene6.ts
+++ b/sample/src/mainScene6.ts
@@ -114,7 +114,8 @@ export function mainScene6(): g.Scene {
 			width: game.width / 4,
 			lineBreak: true,
 			widthAutoAdjust: true,
-			lineBreakRule: sampleRule
+			lineBreakRule: sampleRule,
+			rubyEnabled: true
 		});
 		lblabel2.y = 190;
 		scene.append(lblabel2);


### PR DESCRIPTION
## 概要

サンプルの文字化けているバグを修正
`rubyEnabled:true` 指定がなかったのが原因。文字化けは Labelに指定している `font` に `{}` 等がなかったため文字化けしていた。

`rubyEnabled: true` を指定し解決
<img width="349" alt="label-sample6" src="https://user-images.githubusercontent.com/33408810/226782949-2aa8b7a4-711f-486a-aad7-9f2a1fcc2ec8.png">
